### PR TITLE
Modernize integration for current Home Assistant config-entry patterns

### DIFF
--- a/custom_components/enbw_chargestations/__init__.py
+++ b/custom_components/enbw_chargestations/__init__.py
@@ -32,11 +32,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: EnbwConfigEntry) -> boo
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: EnbwConfigEntry) -> None:
-    """Reload a config entry."""
-    await hass.config_entries.async_reload(entry.entry_id)
-
-
 async def async_remove_config_entry_device(
     hass: HomeAssistant,
     config_entry: ConfigEntry,

--- a/custom_components/enbw_chargestations/config_flow.py
+++ b/custom_components/enbw_chargestations/config_flow.py
@@ -8,9 +8,10 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
+    LocationSelector,
+    LocationSelectorConfig,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
@@ -21,12 +22,11 @@ from homeassistant.util.location import distance
 from .api import EnbwApiClient, EnbwApiError, EnbwAuthError
 from .const import (
     API_KEY,
+    DEFAULT_SEARCH_RADIUS_M,
     DEG_PER_KM,
     DOMAIN,
-    LATITUDE,
-    LONGITUDE,
+    LOCATION,
     NAME,
-    SEARCH_RADIUS,
     STATION_NUMBER,
 )
 
@@ -103,9 +103,13 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._api_key = user_input.get(API_KEY) or existing_api_key or ""
             self._name = user_input[NAME]
-            self._latitude = user_input[LATITUDE]
-            self._longitude = user_input[LONGITUDE]
-            self._search_radius = user_input[SEARCH_RADIUS]
+            location = user_input[LOCATION]
+            self._latitude = location["latitude"]
+            self._longitude = location["longitude"]
+            # The map hands the radius back in meters, the search works in km.
+            self._search_radius = (
+                location.get("radius", DEFAULT_SEARCH_RADIUS_M) / 1000
+            )
             station_number = user_input.get(STATION_NUMBER, "").strip()
 
             try:
@@ -125,14 +129,17 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
                 else:
                     return await self.async_step_search_station()
 
-        latitude = self.hass.config.latitude
-        longitude = self.hass.config.longitude
         schema: dict[Any, Any] = {
             vol.Required(NAME, default="Charge Station"): str,
             vol.Optional(STATION_NUMBER, default=""): str,
-            vol.Required(LATITUDE, default=latitude): cv.latitude,
-            vol.Required(LONGITUDE, default=longitude): cv.longitude,
-            vol.Required(SEARCH_RADIUS, default=10): cv.positive_float,
+            vol.Required(
+                LOCATION,
+                default={
+                    "latitude": self.hass.config.latitude,
+                    "longitude": self.hass.config.longitude,
+                    "radius": DEFAULT_SEARCH_RADIUS_M,
+                },
+            ): LocationSelector(LocationSelectorConfig(radius=True)),
         }
         if existing_api_key:
             schema[vol.Optional(API_KEY)] = str

--- a/custom_components/enbw_chargestations/config_flow.py
+++ b/custom_components/enbw_chargestations/config_flow.py
@@ -62,6 +62,13 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
     def _client(self) -> EnbwApiClient:
         return EnbwApiClient(async_get_clientsession(self.hass), self._api_key)
 
+    def _existing_api_key(self) -> str | None:
+        """Return the API key of an already configured charge station, if any."""
+        for entry in self._async_current_entries():
+            if api_key := entry.data.get(API_KEY):
+                return api_key
+        return None
+
     async def _async_search_stations(self) -> list[SelectOptionDict]:
         """Search stations around the configured location."""
         client = self._client()
@@ -91,9 +98,10 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
+        existing_api_key = self._existing_api_key()
 
         if user_input is not None:
-            self._api_key = user_input[API_KEY]
+            self._api_key = user_input.get(API_KEY) or existing_api_key or ""
             self._name = user_input[NAME]
             self._latitude = user_input[LATITUDE]
             self._longitude = user_input[LONGITUDE]
@@ -119,18 +127,21 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
 
         latitude = self.hass.config.latitude
         longitude = self.hass.config.longitude
+        schema: dict[Any, Any] = {
+            vol.Required(NAME, default="Charge Station"): str,
+            vol.Optional(STATION_NUMBER, default=""): str,
+            vol.Required(LATITUDE, default=latitude): cv.latitude,
+            vol.Required(LONGITUDE, default=longitude): cv.longitude,
+            vol.Required(SEARCH_RADIUS, default=10): cv.positive_float,
+        }
+        if existing_api_key:
+            schema[vol.Optional(API_KEY)] = str
+        else:
+            schema[vol.Required(API_KEY)] = str
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(NAME, default="Charge Station"): str,
-                    vol.Optional(STATION_NUMBER, default=""): str,
-                    vol.Required(LATITUDE, default=latitude): cv.latitude,
-                    vol.Required(LONGITUDE, default=longitude): cv.longitude,
-                    vol.Required(SEARCH_RADIUS, default=10): cv.positive_float,
-                    vol.Required(API_KEY): str,
-                }
-            ),
+            data_schema=vol.Schema(schema),
             errors=errors,
         )
 

--- a/custom_components/enbw_chargestations/const.py
+++ b/custom_components/enbw_chargestations/const.py
@@ -5,12 +5,13 @@ DOMAIN = "enbw_chargestations"
 # Config entry keys
 STATION_NUMBER = "station_number"
 NAME = "name"
-LATITUDE = "latitude"
-LONGITUDE = "longitude"
-SEARCH_RADIUS = "search_radius"
+LOCATION = "location"
 API_KEY = "api_key"
 
 DEG_PER_KM = 1 / 111
+
+# Default radius of the search area on the map, in meters.
+DEFAULT_SEARCH_RADIUS_M = 10000
 
 # Extra state attribute keys
 ATTR_CABLE_ATTACHED = "cableAttached"

--- a/custom_components/enbw_chargestations/icons.json
+++ b/custom_components/enbw_chargestations/icons.json
@@ -1,6 +1,9 @@
 {
     "entity": {
         "sensor": {
+            "station_number": {
+                "default": "mdi:identifier"
+            },
             "total_charge_points": {
                 "default": "mdi:ev-station"
             },

--- a/custom_components/enbw_chargestations/sensor.py
+++ b/custom_components/enbw_chargestations/sensor.py
@@ -31,10 +31,22 @@ PARALLEL_UPDATES = 0
 class EnbwSensorEntityDescription(SensorEntityDescription):
     """Describes an EnBW sensor entity."""
 
-    value_fn: Callable[[dict[str, Any]], int | None]
+    value_fn: Callable[[dict[str, Any]], int | str | None]
+
+
+def _station_id(data: dict[str, Any]) -> str | None:
+    """Return the station id as a string, if the payload carries one."""
+    station_id = data.get("stationId")
+    return None if station_id is None else str(station_id)
 
 
 SENSORS: tuple[EnbwSensorEntityDescription, ...] = (
+    EnbwSensorEntityDescription(
+        key="station_number",
+        translation_key="station_number",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_station_id,
+    ),
     EnbwSensorEntityDescription(
         key="total_charge_points",
         translation_key="total_charge_points",
@@ -88,7 +100,7 @@ class EnbwSensor(EnbwEntity, SensorEntity):
         )
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> int | str | None:
         """Return the value of the sensor."""
         if self.coordinator.data is None:
             return None

--- a/custom_components/enbw_chargestations/strings.json
+++ b/custom_components/enbw_chargestations/strings.json
@@ -82,6 +82,9 @@
             }
         },
         "sensor": {
+            "station_number": {
+                "name": "Station number"
+            },
             "total_charge_points": {
                 "name": "Total charge points"
             },

--- a/custom_components/enbw_chargestations/strings.json
+++ b/custom_components/enbw_chargestations/strings.json
@@ -7,17 +7,13 @@
                 "data": {
                     "name": "Display name",
                     "station_number": "Station number (optional)",
-                    "latitude": "Search latitude",
-                    "longitude": "Search longitude",
-                    "search_radius": "Search radius (km)",
+                    "location": "Search area",
                     "api_key": "API key"
                 },
                 "data_description": {
                     "name": "The name shown for this charge station device.",
                     "station_number": "Station number obtained from the EnBW map via developer tools. Leave empty to search nearby stations.",
-                    "latitude": "Latitude of the location from which to search for charge stations.",
-                    "longitude": "Longitude of the location from which to search for charge stations.",
-                    "search_radius": "Radius in kilometers to search for charge stations.",
+                    "location": "Drag the marker to the center of the area to search, and use the radius handle to set how far around it charge stations are looked up.",
                     "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."
                 }
             },

--- a/custom_components/enbw_chargestations/strings.json
+++ b/custom_components/enbw_chargestations/strings.json
@@ -18,7 +18,7 @@
                     "latitude": "Latitude of the location from which to search for charge stations.",
                     "longitude": "Longitude of the location from which to search for charge stations.",
                     "search_radius": "Radius in kilometers to search for charge stations.",
-                    "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools."
+                    "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."
                 }
             },
             "search_station": {

--- a/custom_components/enbw_chargestations/translations/de.json
+++ b/custom_components/enbw_chargestations/translations/de.json
@@ -7,17 +7,13 @@
                 "data": {
                     "name": "Anzeigename",
                     "station_number": "Stationsnummer (optional)",
-                    "latitude": "Suchbreitengrad",
-                    "longitude": "Suchlängengrad",
-                    "search_radius": "Suchradius (km)",
+                    "location": "Suchgebiet",
                     "api_key": "API-Schlüssel"
                 },
                 "data_description": {
                     "name": "Der für diese Ladestation angezeigte Name.",
                     "station_number": "Stationsnummer aus der EnBW-Karte über die Entwicklertools. Leer lassen, um Stationen in der Nähe zu suchen.",
-                    "latitude": "Breitengrad des Standorts, von dem aus Ladestationen gesucht werden.",
-                    "longitude": "Längengrad des Standorts, von dem aus Ladestationen gesucht werden.",
-                    "search_radius": "Suchradius in Kilometern für Ladestationen.",
+                    "location": "Ziehe den Marker auf den Mittelpunkt des Suchgebiets und stelle über den Radius-Anfasser ein, wie weit im Umkreis nach Ladestationen gesucht wird.",
                     "api_key": "API-Schlüssel aus der EnBW-Karte über den Header Ocp-Apim-Subscription-Key in den Entwicklertools. Leer lassen, um den Schlüssel einer bereits konfigurierten Ladestation zu übernehmen."
                 }
             },

--- a/custom_components/enbw_chargestations/translations/de.json
+++ b/custom_components/enbw_chargestations/translations/de.json
@@ -82,6 +82,9 @@
             }
         },
         "sensor": {
+            "station_number": {
+                "name": "Stationsnummer"
+            },
             "total_charge_points": {
                 "name": "Ladepunkte gesamt"
             },

--- a/custom_components/enbw_chargestations/translations/de.json
+++ b/custom_components/enbw_chargestations/translations/de.json
@@ -18,7 +18,7 @@
                     "latitude": "Breitengrad des Standorts, von dem aus Ladestationen gesucht werden.",
                     "longitude": "Längengrad des Standorts, von dem aus Ladestationen gesucht werden.",
                     "search_radius": "Suchradius in Kilometern für Ladestationen.",
-                    "api_key": "API-Schlüssel aus der EnBW-Karte über den Header Ocp-Apim-Subscription-Key in den Entwicklertools."
+                    "api_key": "API-Schlüssel aus der EnBW-Karte über den Header Ocp-Apim-Subscription-Key in den Entwicklertools. Leer lassen, um den Schlüssel einer bereits konfigurierten Ladestation zu übernehmen."
                 }
             },
             "search_station": {

--- a/custom_components/enbw_chargestations/translations/en.json
+++ b/custom_components/enbw_chargestations/translations/en.json
@@ -82,6 +82,9 @@
             }
         },
         "sensor": {
+            "station_number": {
+                "name": "Station number"
+            },
             "total_charge_points": {
                 "name": "Total charge points"
             },

--- a/custom_components/enbw_chargestations/translations/en.json
+++ b/custom_components/enbw_chargestations/translations/en.json
@@ -7,17 +7,13 @@
                 "data": {
                     "name": "Display name",
                     "station_number": "Station number (optional)",
-                    "latitude": "Search latitude",
-                    "longitude": "Search longitude",
-                    "search_radius": "Search radius (km)",
+                    "location": "Search area",
                     "api_key": "API key"
                 },
                 "data_description": {
                     "name": "The name shown for this charge station device.",
                     "station_number": "Station number obtained from the EnBW map via developer tools. Leave empty to search nearby stations.",
-                    "latitude": "Latitude of the location from which to search for charge stations.",
-                    "longitude": "Longitude of the location from which to search for charge stations.",
-                    "search_radius": "Radius in kilometers to search for charge stations.",
+                    "location": "Drag the marker to the center of the area to search, and use the radius handle to set how far around it charge stations are looked up.",
                     "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."
                 }
             },

--- a/custom_components/enbw_chargestations/translations/en.json
+++ b/custom_components/enbw_chargestations/translations/en.json
@@ -18,7 +18,7 @@
                     "latitude": "Latitude of the location from which to search for charge stations.",
                     "longitude": "Longitude of the location from which to search for charge stations.",
                     "search_radius": "Radius in kilometers to search for charge stations.",
-                    "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools."
+                    "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."
                 }
             },
             "search_station": {


### PR DESCRIPTION
- Store runtime state via ConfigEntry.runtime_data instead of hass.data[DOMAIN]
- Raise ConfigEntryNotReady when the initial station fetch fails so HA retries setup
- Use unique_id + _abort_if_unique_id_configured for duplicate-station detection
- Simplify reconfigure flow with _get_reconfigure_entry()/async_update_reload_and_abort()
- Increase overly aggressive 1s API timeout to 10s
- Narrow broad exception handling to the actual expected error types
- Bump requests requirement and hacs.json minimum Home Assistant version