### PR TITLE
Hinzufügen der Stationen überarbeitet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ own device with its own set of entities.
 2. Add the repo as a custom repository
 3. Install the integration
 4. Restart HomeAssistant
-5. Acquire a API Key and Station Number if preferred (This can be done using the developer tools of your browser)
+5. Acquire an API Key (This can be done using the developer tools of your browser)
     
     * Open the [map](https://www.enbw.com/elektromobilitaet/produkte/mobilityplus-app/ladestation-finden/map) to find nearby charge stations.
     * Open the development tools and network monitor of your browser
@@ -40,16 +40,19 @@ own device with its own set of entities.
       ```
       https://enbw-emp.azure-api.net/emobility-public-api/api/v1/chargestations/{STATION_NUMBER}
       ```
-      You can also use the station number at the end of the request for the setup.
     * Open the request and search for the API Key in the headers. It is a hexadecimal value and will look like this:
       ```
       Ocp-Apim-Subscription-Key: {API_KEY}
       ```
-3. Add the Integration from the HomeAssistant UI
-4. Provide the API-Key
-5. Optional: Provide a Station Number (may be needed if your desired station is not shown in the search list)
-6. If station number was not provided, select one from the list.
-7. Enjoy
+6. Add the Integration from the HomeAssistant UI
+7. Provide the API-Key (this can be left empty once a first charge station is set up — the stored key is reused)
+8. Move the marker on the map to the area you want to search, and set the radius around it
+9. Select a station from the list of results
+10. Enjoy
+
+If the station you want does not show up in the results, enlarge the search
+radius or move the marker closer to it. A specific station number can also be
+set afterwards via **Configure** on the integration entry.
 
 ## Removing the integration
 

--- a/custom_components/enbw_chargestations/config_flow.py
+++ b/custom_components/enbw_chargestations/config_flow.py
@@ -176,7 +176,7 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
                         SelectSelectorConfig(
                             options=self._station_options,
                             multiple=False,
-                            mode=SelectSelectorMode.LIST,
+                            mode=SelectSelectorMode.DROPDOWN,
                         )
                     ),
                 }

--- a/custom_components/enbw_chargestations/config_flow.py
+++ b/custom_components/enbw_chargestations/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     DEG_PER_KM,
     DOMAIN,
     LOCATION,
+    MAX_SEARCH_RESULTS,
     NAME,
     STATION_NUMBER,
 )
@@ -97,7 +98,7 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
             if station.get("stationId") is not None
         ]
         scored.sort(key=lambda item: item[1])
-        nearest = scored[:15]
+        nearest = scored[:MAX_SEARCH_RESULTS]
         self._station_names = {
             str(station["stationId"]): _station_name(
                 station, str(station["stationId"])

--- a/custom_components/enbw_chargestations/config_flow.py
+++ b/custom_components/enbw_chargestations/config_flow.py
@@ -45,6 +45,12 @@ def _station_option(station: dict[str, Any], distance_m: float) -> SelectOptionD
     )
 
 
+def _station_name(station: dict[str, Any], station_number: str) -> str:
+    """Derive the entry name from the station itself."""
+    address = station.get("shortAddress")
+    return str(address) if address else f"Charge station {station_number}"
+
+
 class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for EnBW Charge Stations."""
 
@@ -53,11 +59,11 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize."""
         self._api_key: str = ""
-        self._name: str = "Charge Station"
         self._latitude: float = 0
         self._longitude: float = 0
         self._search_radius: float = 10
         self._station_options: list[SelectOptionDict] = []
+        self._station_names: dict[str, str] = {}
 
     def _client(self) -> EnbwApiClient:
         return EnbwApiClient(async_get_clientsession(self.hass), self._api_key)
@@ -91,7 +97,14 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
             if station.get("stationId") is not None
         ]
         scored.sort(key=lambda item: item[1])
-        return [_station_option(station, dist) for station, dist in scored[:15]]
+        nearest = scored[:15]
+        self._station_names = {
+            str(station["stationId"]): _station_name(
+                station, str(station["stationId"])
+            )
+            for station, _ in nearest
+        }
+        return [_station_option(station, dist) for station, dist in nearest]
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -102,7 +115,6 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._api_key = user_input.get(API_KEY) or existing_api_key or ""
-            self._name = user_input[NAME]
             location = user_input[LOCATION]
             self._latitude = location["latitude"]
             self._longitude = location["longitude"]
@@ -114,9 +126,14 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 if station_number:
-                    # Validate the explicit station number.
-                    await self._client().async_get_charge_station(station_number)
-                    return await self._async_create(station_number)
+                    # Validate the explicit station number, and name the entry
+                    # after the station it turns out to be.
+                    station = await self._client().async_get_charge_station(
+                        station_number
+                    )
+                    return await self._async_create(
+                        station_number, _station_name(station, station_number)
+                    )
 
                 self._station_options = await self._async_search_stations()
             except EnbwAuthError:
@@ -130,7 +147,6 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_search_station()
 
         schema: dict[Any, Any] = {
-            vol.Required(NAME, default="Charge Station"): str,
             vol.Optional(STATION_NUMBER, default=""): str,
             vol.Required(
                 LOCATION,
@@ -157,7 +173,13 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle selecting a station from the search results."""
         if user_input is not None:
-            return await self._async_create(user_input[STATION_NUMBER])
+            station_number = user_input[STATION_NUMBER]
+            return await self._async_create(
+                station_number,
+                self._station_names.get(
+                    station_number, f"Charge station {station_number}"
+                ),
+            )
 
         return self.async_show_form(
             step_id="search_station",
@@ -174,16 +196,18 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def _async_create(self, station_number: str) -> ConfigFlowResult:
+    async def _async_create(
+        self, station_number: str, name: str
+    ) -> ConfigFlowResult:
         """Create the config entry for the selected station."""
         await self.async_set_unique_id(station_number)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(
-            title=self._name,
+            title=name,
             data={
                 STATION_NUMBER: station_number,
                 API_KEY: self._api_key,
-                NAME: self._name,
+                NAME: name,
             },
         )
 

--- a/custom_components/enbw_chargestations/config_flow.py
+++ b/custom_components/enbw_chargestations/config_flow.py
@@ -122,19 +122,7 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
             self._search_radius = (
                 location.get("radius", DEFAULT_SEARCH_RADIUS_M) / 1000
             )
-            station_number = user_input.get(STATION_NUMBER, "").strip()
-
             try:
-                if station_number:
-                    # Validate the explicit station number, and name the entry
-                    # after the station it turns out to be.
-                    station = await self._client().async_get_charge_station(
-                        station_number
-                    )
-                    return await self._async_create(
-                        station_number, _station_name(station, station_number)
-                    )
-
                 self._station_options = await self._async_search_stations()
             except EnbwAuthError:
                 errors["base"] = "invalid_auth"
@@ -147,7 +135,6 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_search_station()
 
         schema: dict[Any, Any] = {
-            vol.Optional(STATION_NUMBER, default=""): str,
             vol.Required(
                 LOCATION,
                 default={

--- a/custom_components/enbw_chargestations/const.py
+++ b/custom_components/enbw_chargestations/const.py
@@ -13,6 +13,9 @@ DEG_PER_KM = 1 / 111
 # Default radius of the search area on the map, in meters.
 DEFAULT_SEARCH_RADIUS_M = 10000
 
+# How many of the nearest stations to offer in the search results.
+MAX_SEARCH_RESULTS = 50
+
 # Extra state attribute keys
 ATTR_CABLE_ATTACHED = "cableAttached"
 ATTR_PLUG_TYPE_NAME = "plugTypeName"

--- a/custom_components/enbw_chargestations/strings.json
+++ b/custom_components/enbw_chargestations/strings.json
@@ -5,12 +5,10 @@
                 "title": "Add EnBW charge station",
                 "description": "Provide configuration data. See documentation for further info.",
                 "data": {
-                    "station_number": "Station number (optional)",
                     "location": "Search area",
                     "api_key": "API key"
                 },
                 "data_description": {
-                    "station_number": "Station number obtained from the EnBW map via developer tools. Leave empty to search nearby stations.",
                     "location": "Drag the marker to the center of the area to search, and use the radius handle to set how far around it charge stations are looked up.",
                     "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."
                 }

--- a/custom_components/enbw_chargestations/strings.json
+++ b/custom_components/enbw_chargestations/strings.json
@@ -5,13 +5,11 @@
                 "title": "Add EnBW charge station",
                 "description": "Provide configuration data. See documentation for further info.",
                 "data": {
-                    "name": "Display name",
                     "station_number": "Station number (optional)",
                     "location": "Search area",
                     "api_key": "API key"
                 },
                 "data_description": {
-                    "name": "The name shown for this charge station device.",
                     "station_number": "Station number obtained from the EnBW map via developer tools. Leave empty to search nearby stations.",
                     "location": "Drag the marker to the center of the area to search, and use the radius handle to set how far around it charge stations are looked up.",
                     "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."

--- a/custom_components/enbw_chargestations/translations/de.json
+++ b/custom_components/enbw_chargestations/translations/de.json
@@ -5,12 +5,10 @@
                 "title": "EnBW-Ladestation hinzufügen",
                 "description": "Konfigurationsdaten angeben. Weitere Infos in der Dokumentation.",
                 "data": {
-                    "station_number": "Stationsnummer (optional)",
                     "location": "Suchgebiet",
                     "api_key": "API-Schlüssel"
                 },
                 "data_description": {
-                    "station_number": "Stationsnummer aus der EnBW-Karte über die Entwicklertools. Leer lassen, um Stationen in der Nähe zu suchen.",
                     "location": "Ziehe den Marker auf den Mittelpunkt des Suchgebiets und stelle über den Radius-Anfasser ein, wie weit im Umkreis nach Ladestationen gesucht wird.",
                     "api_key": "API-Schlüssel aus der EnBW-Karte über den Header Ocp-Apim-Subscription-Key in den Entwicklertools. Leer lassen, um den Schlüssel einer bereits konfigurierten Ladestation zu übernehmen."
                 }

--- a/custom_components/enbw_chargestations/translations/de.json
+++ b/custom_components/enbw_chargestations/translations/de.json
@@ -5,13 +5,11 @@
                 "title": "EnBW-Ladestation hinzufügen",
                 "description": "Konfigurationsdaten angeben. Weitere Infos in der Dokumentation.",
                 "data": {
-                    "name": "Anzeigename",
                     "station_number": "Stationsnummer (optional)",
                     "location": "Suchgebiet",
                     "api_key": "API-Schlüssel"
                 },
                 "data_description": {
-                    "name": "Der für diese Ladestation angezeigte Name.",
                     "station_number": "Stationsnummer aus der EnBW-Karte über die Entwicklertools. Leer lassen, um Stationen in der Nähe zu suchen.",
                     "location": "Ziehe den Marker auf den Mittelpunkt des Suchgebiets und stelle über den Radius-Anfasser ein, wie weit im Umkreis nach Ladestationen gesucht wird.",
                     "api_key": "API-Schlüssel aus der EnBW-Karte über den Header Ocp-Apim-Subscription-Key in den Entwicklertools. Leer lassen, um den Schlüssel einer bereits konfigurierten Ladestation zu übernehmen."

--- a/custom_components/enbw_chargestations/translations/en.json
+++ b/custom_components/enbw_chargestations/translations/en.json
@@ -5,12 +5,10 @@
                 "title": "Add EnBW charge station",
                 "description": "Provide configuration data. See documentation for further info.",
                 "data": {
-                    "station_number": "Station number (optional)",
                     "location": "Search area",
                     "api_key": "API key"
                 },
                 "data_description": {
-                    "station_number": "Station number obtained from the EnBW map via developer tools. Leave empty to search nearby stations.",
                     "location": "Drag the marker to the center of the area to search, and use the radius handle to set how far around it charge stations are looked up.",
                     "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."
                 }

--- a/custom_components/enbw_chargestations/translations/en.json
+++ b/custom_components/enbw_chargestations/translations/en.json
@@ -5,13 +5,11 @@
                 "title": "Add EnBW charge station",
                 "description": "Provide configuration data. See documentation for further info.",
                 "data": {
-                    "name": "Display name",
                     "station_number": "Station number (optional)",
                     "location": "Search area",
                     "api_key": "API key"
                 },
                 "data_description": {
-                    "name": "The name shown for this charge station device.",
                     "station_number": "Station number obtained from the EnBW map via developer tools. Leave empty to search nearby stations.",
                     "location": "Drag the marker to the center of the area to search, and use the radius handle to set how far around it charge stations are looked up.",
                     "api_key": "API key obtained from the EnBW map via the Ocp-Apim-Subscription-Key header in developer tools. Leave empty to reuse the key from an already configured charge station."


### PR DESCRIPTION
Derive the display name from the station. The name field is gone from the dialog. The entry is named after the station's address, carried over from the search results for the station actually selected. Stations without an address fall back to Charge station <number>.

Drop the station number field. Stations are now always picked from the map search results, so the manual station number entry (and its developer-tools lookup) is no longer part of adding a station.

Searchable dropdown, up to 50 results. The station picker switches from a radio list to SelectSelectorMode.DROPDOWN, which filters as you type; option labels carry the address, distance and power, so any of those narrows the list. The result cap moves from 15 to MAX_SEARCH_RESULTS = 50, which was tight for dense areas — the nearest stations are still the ones kept when the cap bites.

The reconfigure step is unchanged and still exposes name, station number and API key — that remains the way to point an entry at a specific station or rename it. Field labels and descriptions updated in strings.json and both translations; README setup steps rewritten to match.