### PR TITLE
Ask for the API key first in the add dialog

### DIFF
--- a/custom_components/enbw_chargestations/config_flow.py
+++ b/custom_components/enbw_chargestations/config_flow.py
@@ -135,7 +135,13 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
                 else:
                     return await self.async_step_search_station()
 
-        schema: dict[Any, Any] = {
+        # The API key comes first, the search area map below it.
+        schema: dict[Any, Any] = {}
+        if existing_api_key:
+            schema[vol.Optional(API_KEY)] = str
+        else:
+            schema[vol.Required(API_KEY)] = str
+        schema[
             vol.Required(
                 LOCATION,
                 default={
@@ -143,12 +149,8 @@ class EnbwChargeStationsConfigFlow(ConfigFlow, domain=DOMAIN):
                     "longitude": self.hass.config.longitude,
                     "radius": DEFAULT_SEARCH_RADIUS_M,
                 },
-            ): LocationSelector(LocationSelectorConfig(radius=True)),
-        }
-        if existing_api_key:
-            schema[vol.Optional(API_KEY)] = str
-        else:
-            schema[vol.Required(API_KEY)] = str
+            )
+        ] = LocationSelector(LocationSelectorConfig(radius=True))
 
         return self.async_show_form(
             step_id="user",

--- a/tests/test_no_station_number_field.py
+++ b/tests/test_no_station_number_field.py
@@ -49,7 +49,8 @@ async def test_user_step_only_asks_for_area_and_key(hass):
         "enbw_chargestations", context={"source": "user"}
     )
     keys = [str(marker) for marker in result["data_schema"].schema]
-    assert keys == ["location", "api_key"]
+    # The API key is asked for first, the search area map below it.
+    assert keys == ["api_key", "location"]
 
 @pytest.mark.asyncio
 async def test_flow_always_goes_through_the_map_search(


### PR DESCRIPTION
The API key field now comes before the search area map so it is the first thing filled in when adding a charge station.


Claude-Session: https://claude.ai/code/session_013bfE9QSp42UvUyA1EW6HVw